### PR TITLE
Bugfix: Expired tokens pass claims validation successfully

### DIFF
--- a/auth0.go
+++ b/auth0.go
@@ -45,7 +45,7 @@ type Configuration struct {
 func NewConfiguration(provider SecretProvider, audience []string, issuer string, method jose.SignatureAlgorithm) Configuration {
 	return Configuration{
 		secretProvider: provider,
-		expectedClaims: jwt.Expected{Issuer: issuer, Audience: audience},
+		expectedClaims: jwt.Expected{Issuer: issuer, Audience: audience, Time: time.Now()},
 		signIn:         method,
 		exp:            0,
 		nbf:            0,


### PR DESCRIPTION
Hi @yageek , please check this PR.

Time property not set in expectedClaims when creating configuration. This skips validation for exp (and nbf), so expired tokens are still treated as valid.