### PR TITLE
Add token extractor for URL params

### DIFF
--- a/auth0.go
+++ b/auth0.go
@@ -62,8 +62,11 @@ type JWTValidator struct {
 
 // NewValidator creates a new
 // validator with the provided configuration.
-func NewValidator(config Configuration) *JWTValidator {
-	return &JWTValidator{config, RequestTokenExtractorFunc(FromHeader)}
+func NewValidator(config Configuration, extractor RequestTokenExtractor) *JWTValidator {
+	if extractor == nil {
+		extractor = RequestTokenExtractorFunc(FromHeader)
+	}
+	return &JWTValidator{config, extractor}
 }
 
 // ValidateRequest validates the token within

--- a/auth0_test.go
+++ b/auth0_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func validConfiguration(configuration Configuration, tokenRaw string) error {
-	validator := NewValidator(configuration)
+	validator := NewValidator(configuration, nil)
 	headerTokenRequest, _ := http.NewRequest("", "http://localhost", nil)
 	headerValue := fmt.Sprintf("Bearer %s", tokenRaw)
 	headerTokenRequest.Header.Add("Authorization", headerValue)
@@ -86,7 +86,7 @@ func TestInvalidProvider(t *testing.T) {
 func TestClaims(t *testing.T) {
 
 	configuration := NewConfiguration(defaultSecretProvider, defaultAudience, defaultIssuer, jose.HS256)
-	validator := NewValidator(configuration)
+	validator := NewValidator(configuration, nil)
 	token := getTestToken(defaultAudience, defaultIssuer, time.Now().Add(24*time.Hour), jose.HS256, defaultSecret)
 
 	headerTokenRequest, _ := http.NewRequest("", "http://localhost", nil)

--- a/token_extraction.go
+++ b/token_extraction.go
@@ -1,17 +1,17 @@
 package auth0
 
 import (
-
-	"net/http"
-	"gopkg.in/square/go-jose.v2/jwt"
-	"strings"
 	"errors"
+	"net/http"
+	"strings"
 
+	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 var (
 	ErrTokenNotFound = errors.New("Token not found")
 )
+
 // RequestTokenExtractor can extract a JWT
 // from a request.
 type RequestTokenExtractor interface {
@@ -42,6 +42,22 @@ func FromHeader(r *http.Request) (*jwt.JSONWebToken, error) {
 func fromHeader(r *http.Request) ([]byte, error) {
 	if authorizationHeader := r.Header.Get("Authorization"); len(authorizationHeader) > 7 && strings.EqualFold(authorizationHeader[0:7], "BEARER ") {
 		return []byte(authorizationHeader[7:]), nil
+	}
+	return nil, ErrTokenNotFound
+}
+
+// FromParams returns the JWT when passed as the URL query param "token".
+func FromParams(r *http.Request) (*jwt.JSONWebToken, error) {
+	raw, err := fromParams(r)
+	if err != nil {
+		return nil, err
+	}
+	return jwt.ParseSigned(string(raw))
+}
+
+func fromParams(r *http.Request) ([]byte, error) {
+	if token := r.URL.Query().Get("token"); token != "" {
+		return []byte(token), nil
 	}
 	return nil, ErrTokenNotFound
 }

--- a/token_extraction.go
+++ b/token_extraction.go
@@ -27,11 +27,23 @@ func (f RequestTokenExtractorFunc) Extract(r *http.Request) (*jwt.JSONWebToken, 
 	return f(r)
 }
 
+// FromMultiple combines multiple extractors by chaining.
+func FromMultiple(extractors ...RequestTokenExtractor) RequestTokenExtractor {
+	return RequestTokenExtractorFunc(func(r *http.Request) (*jwt.JSONWebToken, error) {
+		for _, e := range extractors {
+			if token, err := e.Extract(r); err == nil {
+				return token, nil
+			}
+		}
+		return nil, ErrTokenNotFound
+	})
+}
+
 // FromHeader looks for the request in the
 // authentication header or call ParseMultipartForm
 // if not present.
+// TODO: Implement parsing form data.
 func FromHeader(r *http.Request) (*jwt.JSONWebToken, error) {
-
 	raw, err := fromHeader(r)
 	if err != nil {
 		return nil, err

--- a/token_extraction_test.go
+++ b/token_extraction_test.go
@@ -8,19 +8,40 @@ import (
 	"time"
 
 	"gopkg.in/square/go-jose.v2"
-
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
-func TestFromRequestExtraction(t *testing.T) {
+func TestFromRequestHeaderExtraction(t *testing.T) {
 	referenceToken := getTestToken(defaultAudience, defaultIssuer, time.Now(), jose.HS256, defaultSecret)
-	headerTokenRequest, _ := http.NewRequest("", "http://localhost", nil)
 
+	headerTokenRequest, _ := http.NewRequest("", "http://localhost", nil)
 	headerValue := fmt.Sprintf("Bearer %s", referenceToken)
 	headerTokenRequest.Header.Add("Authorization", headerValue)
 
 	token, err := FromHeader(headerTokenRequest)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
+	claims := jwt.Claims{}
+	err = token.Claims([]byte("secret"), &claims)
+	if err != nil {
+		t.Errorf("Claims should be decoded correctly with default token: %q \n", err)
+		t.FailNow()
+	}
+
+	if claims.Issuer != defaultIssuer || !reflect.DeepEqual(claims.Audience, jwt.Audience(defaultAudience)) {
+		t.Error("Invalid issuer, audience or subject:", claims.Issuer, claims.Audience)
+	}
+}
+
+func TestFromRequestParamsExtraction(t *testing.T) {
+	referenceToken := getTestToken(defaultAudience, defaultIssuer, time.Now(), jose.HS256, defaultSecret)
+
+	paramTokenRequest, _ := http.NewRequest("", "http://localhost?token="+referenceToken, nil)
+
+	token, err := FromParams(paramTokenRequest)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
This PR also adds a `FromMultiple` extractor to combine multiple extractors by changing them.

I needed the URL params extractor to be able to support JWT auth of web sockets, even if passing te access token as a URL params is discouraged.