### PR TITLE
Add new params to JWKClient example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ if err != nil {
 ## API with JWK
 
 ```go
-client := NewJWKClient(JWKClientOptions{URI: "https://mydomain.eu.auth0.com/.well-known/jwks.json"})
+client := NewJWKClient(JWKClientOptions{URI: "https://mydomain.eu.auth0.com/.well-known/jwks.json"}, nil)
 audience := os.Getenv("AUTH0_CLIENT_ID")
 configuration := NewConfiguration(client, []string{audience}, "https://mydomain.eu.auth0.com/", jose.RS256)
 validator := NewValidator(configuration, nil)


### PR DESCRIPTION
The JWKClient is now allowed to use a custom extractor. However, the example in the Readme hasn't been updated to reflect that change.
```go
client := NewJWKClient(JWKClientOptions{URI: "https://mydomain.eu.auth0.com/.well-known/jwks.json"}, nil)
```