### PR TITLE
Remove hardcoded sig alg check in JWKClient GetSecret

### DIFF
--- a/auth0_test.go
+++ b/auth0_test.go
@@ -23,9 +23,20 @@ func validConfiguration(configuration Configuration, tokenRaw string) error {
 
 func TestValidatorFull(t *testing.T) {
 
+	// HS256
 	token := getTestToken(defaultAudience, defaultIssuer, time.Now().Add(24*time.Hour), jose.HS256, defaultSecret)
 	configuration := NewConfiguration(defaultSecretProvider, defaultAudience, defaultIssuer, jose.HS256)
 	err := validConfiguration(configuration, token)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// ES384
+	jsonWebKeyES384 := genECDSAJWK(jose.ES384, "")
+	tokenES384 := getTestToken(defaultAudience, defaultIssuer, time.Now().Add(24*time.Hour), jose.ES384, jsonWebKeyES384)
+	configurationES384 := NewConfiguration(NewKeyProvider(jsonWebKeyES384.Public()), defaultAudience, defaultIssuer, jose.ES384)
+	err = validConfiguration(configurationES384, tokenES384)
 
 	if err != nil {
 		t.Error(err)

--- a/auth0_test.go
+++ b/auth0_test.go
@@ -111,6 +111,16 @@ func TestClaims(t *testing.T) {
 	}
 }
 
+func TestTokenAlgValidity(t *testing.T) {
+	token := getTestToken([]string{"required"}, "", time.Now().Add(24*time.Hour), jose.HS384, defaultSecret)
+	configuration := NewConfiguration(defaultSecretProvider, defaultAudience, defaultIssuer, jose.HS256)
+	err := validConfiguration(configuration, token)
+
+	if err == nil {
+		t.Error("Should failed if the token was not of a valid type")
+	}
+}
+
 func TestTokenTimeValidity(t *testing.T) {
 	expiredToken := getTestToken(defaultAudience, defaultIssuer, time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC), jose.HS256, defaultSecret)
 	configuration := NewConfiguration(defaultSecretProvider, defaultAudience, defaultIssuer, jose.HS256)

--- a/common_test.go
+++ b/common_test.go
@@ -1,6 +1,10 @@
 package auth0
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
 	"time"
 
 	jose "gopkg.in/square/go-jose.v2"
@@ -15,8 +19,69 @@ var (
 	defaultSecretProvider = NewKeyProvider(defaultSecret)
 )
 
+func genRSASSAJWK(sigAlg jose.SignatureAlgorithm, kid string) jose.JSONWebKey {
+	var bits int
+	if sigAlg == jose.RS256 {
+		bits = 2048
+	}
+	if sigAlg == jose.RS512 {
+		bits = 4096
+	}
+
+	key, _ := rsa.GenerateKey(rand.Reader, bits)
+
+	jsonWebKey := jose.JSONWebKey{
+		Key:       key,
+		KeyID:     kid,
+		Use:       "sig",
+		Algorithm: string(sigAlg),
+	}
+
+	return jsonWebKey
+}
+
+func genECDSAJWK(sigAlg jose.SignatureAlgorithm, kid string) jose.JSONWebKey {
+	var c elliptic.Curve
+	if sigAlg == jose.ES256 {
+		c = elliptic.P256()
+	}
+	if sigAlg == jose.ES384 {
+		c = elliptic.P384()
+	}
+
+	key, _ := ecdsa.GenerateKey(c, rand.Reader)
+
+	jsonWebKey := jose.JSONWebKey{
+		Key:       key,
+		KeyID:     kid,
+		Algorithm: string(sigAlg),
+	}
+
+	return jsonWebKey
+}
+
 func getTestToken(audience []string, issuer string, expTime time.Time, alg jose.SignatureAlgorithm, key interface{}) string {
 	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: alg, Key: key}, (&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		panic(err)
+	}
+
+	cl := jwt.Claims{
+		Issuer:   issuer,
+		Audience: audience,
+		IssuedAt: jwt.NewNumericDate(time.Now().UTC()),
+		Expiry:   jwt.NewNumericDate(expTime),
+	}
+
+	raw, err := jwt.Signed(signer).Claims(cl).CompactSerialize()
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+func getTestTokenWithKid(audience []string, issuer string, expTime time.Time, alg jose.SignatureAlgorithm, key interface{}, kid string) string {
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: alg, Key: key}, (&jose.SignerOptions{ExtraHeaders: map[jose.HeaderKey]interface{}{"kid": kid}}).WithType("JWT"))
 	if err != nil {
 		panic(err)
 	}

--- a/jwk_client.go
+++ b/jwk_client.go
@@ -13,7 +13,7 @@ import (
 var (
 	ErrInvalidContentType = errors.New("Should have a JSON content type for JWKS endpoint.")
 	ErrNoKeyFound         = errors.New("No Keys has been found")
-	ErrInvalidAlgorithm   = errors.New("Only RS256 is supported")
+	ErrInvalidAlgorithm   = errors.New("Algorithm is invalid")
 )
 
 type JWKClientOptions struct {
@@ -111,9 +111,6 @@ func (j *JWKClient) GetSecret(r *http.Request) (interface{}, error) {
 	}
 
 	header := token.Headers[0]
-	if header.Algorithm != "RS256" {
-		return nil, ErrInvalidAlgorithm
-	}
 
 	return j.GetKey(header.KeyID)
 }


### PR DESCRIPTION
We would like to use this library to retrieve JWKS and validate JWTs, not limiting to `Auth0` and `RS256`.

The hardcoded alg type check in the `GetSecret` in `JWKClient` prevents us from doing so, and I think it could be safely removed since `ValidateRequest` in `JWTValidator` (line 86 in auth0.go) already checks for the alg type from the JWT.

A benefit from keeping an alg type check in `JWKClient` if it's used directly could be to help mitigate potential DOS attacks, so the JWKS endpoint won't be constantly hit since the bad jwt `KID` isn't in the cache, but the attacker could also try all possible alg types and time the requests to see which one takes the most time to process, in turn figuring out which alg type to attack with.

Another way to open up the `JWKClient` could be to include the alg type as a passable option, but that may break backwards compatibility.

See updated tests for use cases with `ECDSA` alg type tokens.