### PR TITLE
Add support for ValidateWithLeeway

### DIFF
--- a/auth0.go
+++ b/auth0.go
@@ -80,7 +80,19 @@ func NewValidator(config Configuration, extractor RequestTokenExtractor) *JWTVal
 
 // ValidateRequest validates the token within
 // the http request.
+// A default leeway value of one minute is used to compare time values.
 func (v *JWTValidator) ValidateRequest(r *http.Request) (*jwt.JSONWebToken, error) {
+	return v.validateRequestWithLeeway(r, jwt.DefaultLeeway)
+}
+
+// ValidateRequestWithLeeway validates the token within
+// the http request.
+// The provided leeway value is used to compare time values.
+func (v *JWTValidator) ValidateRequestWithLeeway(r *http.Request, leeway time.Duration) (*jwt.JSONWebToken, error) {
+	return v.validateRequestWithLeeway(r, leeway)
+}
+
+func (v *JWTValidator) validateRequestWithLeeway(r *http.Request, leeway time.Duration) (*jwt.JSONWebToken, error) {
 	token, err := v.extractor.Extract(r)
 	if err != nil {
 		return nil, err
@@ -109,7 +121,7 @@ func (v *JWTValidator) ValidateRequest(r *http.Request) (*jwt.JSONWebToken, erro
 	}
 
 	expected := v.config.expectedClaims.WithTime(time.Now())
-	err = claims.Validate(expected)
+	err = claims.ValidateWithLeeway(expected, leeway)
 	return token, err
 }
 

--- a/auth0_test.go
+++ b/auth0_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 func genTestConfiguration(configuration Configuration, token string) (*JWTValidator, *http.Request) {
@@ -243,6 +244,279 @@ func TestValidateRequestAndClaims(t *testing.T) {
 			validator, req := genTestConfiguration(test.configuration, test.token)
 
 			jwt, err := validator.ValidateRequest(req)
+
+			if test.expectedErrorMsg != "" {
+				if err == nil {
+					t.Errorf("Validation should have failed with error with substring: " + test.expectedErrorMsg)
+				} else if !strings.Contains(err.Error(), test.expectedErrorMsg) {
+					t.Errorf("Validation should have failed with error with substring: " + test.expectedErrorMsg + ", but got: " + err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validation should not have failed with error, but got: " + err.Error())
+				}
+
+				// claims should be unmarshalled successfully
+				claims := map[string]interface{}{}
+				err = validator.Claims(req, jwt, &claims)
+				if err != nil {
+					t.Errorf("Claims unmarshall should not have failed with error, but got: " + err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestValidateRequestAndClaimsWithLeeway(t *testing.T) {
+	tests := []struct {
+		name string
+		// validator config
+		configuration Configuration
+		// token attr
+		token string
+		// leeway
+		leeway time.Duration
+		// test result
+		expectedErrorMsg string
+	}{
+		{
+			name: "pass - token HS256",
+			configuration: NewConfiguration(
+				defaultSecretProvider,
+				defaultAudience,
+				defaultIssuer,
+				jose.HS256,
+			),
+			token: getTestToken(
+				defaultAudience,
+				defaultIssuer,
+				time.Now().Add(24*time.Hour),
+				jose.HS256,
+				defaultSecret,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "",
+		},
+		{
+			name: "pass - token ES384",
+			configuration: NewConfiguration(
+				defaultSecretProviderES384,
+				defaultAudience,
+				defaultIssuer,
+				jose.ES384,
+			),
+			token: getTestToken(
+				defaultAudience,
+				defaultIssuer,
+				time.Now().Add(24*time.Hour),
+				jose.ES384,
+				defaultSecretES384,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "",
+		},
+		{
+			name: "pass - token, config empty iss, aud",
+			configuration: NewConfiguration(
+				defaultSecretProvider,
+				emptyAudience,
+				emptyIssuer,
+				jose.HS256,
+			),
+			token: getTestToken(
+				emptyAudience,
+				emptyIssuer,
+				time.Now().Add(24*time.Hour),
+				jose.HS256,
+				defaultSecret,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "",
+		},
+		{
+			name: "pass - token HS256 config no enforce sig alg",
+			configuration: NewConfigurationTrustProvider(
+				defaultSecretProvider,
+				defaultAudience,
+				defaultIssuer,
+			),
+			token: getTestToken(
+				defaultAudience,
+				defaultIssuer,
+				time.Now().Add(24*time.Hour),
+				jose.HS256,
+				defaultSecret,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "",
+		},
+		{
+			name: "pass - token ES384 config no enforce sig alg",
+			configuration: NewConfigurationTrustProvider(
+				defaultSecretProviderES384,
+				defaultAudience,
+				defaultIssuer,
+			),
+			token: getTestToken(
+				defaultAudience,
+				defaultIssuer,
+				time.Now().Add(24*time.Hour),
+				jose.ES384,
+				defaultSecretES384,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "",
+		},
+		{
+			name: "pass - token not expired because of leeway",
+			configuration: NewConfiguration(
+				defaultSecretProvider,
+				defaultAudience,
+				defaultIssuer,
+				jose.HS256,
+			),
+			token: getTestToken(
+				defaultAudience,
+				defaultIssuer,
+				time.Now().Add(-1*time.Minute),
+				jose.HS256,
+				defaultSecret,
+			),
+			leeway:           2 * time.Minute,
+			expectedErrorMsg: "",
+		},
+		{
+			name: "fail - config no enforce sig alg but invalid token alg",
+			configuration: NewConfigurationTrustProvider(
+				defaultSecretProviderES384,
+				defaultAudience,
+				defaultIssuer,
+			),
+			token: getTestToken(
+				defaultAudience,
+				defaultIssuer,
+				time.Now().Add(24*time.Hour),
+				jose.RS256,
+				defaultSecretRS256,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "error in cryptographic primitive",
+		},
+		{
+			name: "fail - invalid config secret provider",
+			configuration: NewConfiguration(
+				SecretProviderFunc(invalidProvider),
+				defaultAudience,
+				defaultIssuer,
+				jose.HS256,
+			),
+			token: getTestToken(
+				defaultAudience,
+				defaultIssuer,
+				time.Now().Add(24*time.Hour),
+				jose.HS256,
+				defaultSecret,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "invalid secret provider",
+		},
+		{
+			name: "fail - invalid token aud",
+			configuration: NewConfiguration(
+				defaultSecretProvider,
+				defaultAudience,
+				defaultIssuer,
+				jose.HS256,
+			),
+			token: getTestToken(
+				[]string{"invalid aud"},
+				defaultIssuer,
+				time.Now().Add(24*time.Hour),
+				jose.HS256,
+				defaultSecret,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "invalid audience claim (aud)",
+		},
+		{
+			name: "fail - invalid token iss",
+			configuration: NewConfiguration(
+				defaultSecretProvider,
+				defaultAudience,
+				defaultIssuer,
+				jose.HS256,
+			),
+			token: getTestToken(
+				defaultAudience,
+				"invalid iss",
+				time.Now().Add(24*time.Hour),
+				jose.HS256,
+				defaultSecret,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "invalid issuer claim (iss)",
+		},
+		{
+			name: "fail - invalid token expiry",
+			configuration: NewConfiguration(
+				defaultSecretProvider,
+				defaultAudience,
+				defaultIssuer,
+				jose.HS256,
+			),
+			token: getTestToken(
+				defaultAudience,
+				defaultIssuer,
+				time.Now().Add(-24*time.Hour),
+				jose.HS256,
+				defaultSecret,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "token is expired (exp)",
+		},
+		{
+			name: "fail - invalid token alg",
+			configuration: NewConfiguration(
+				defaultSecretProvider,
+				defaultAudience,
+				defaultIssuer,
+				jose.HS256,
+			),
+			token: getTestToken(
+				defaultAudience,
+				defaultIssuer,
+				time.Now().Add(-24*time.Hour),
+				jose.HS384,
+				defaultSecret,
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "algorithm is invalid",
+		},
+		{
+			name: "fail - invalid token secret",
+			configuration: NewConfiguration(
+				defaultSecretProvider,
+				defaultAudience,
+				defaultIssuer,
+				jose.HS256,
+			),
+			token: getTestToken(
+				defaultAudience,
+				defaultIssuer,
+				time.Now().Add(24*time.Hour),
+				jose.HS256,
+				[]byte("invalid secret"),
+			),
+			leeway:           jwt.DefaultLeeway,
+			expectedErrorMsg: "error in cryptographic primitive",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			validator, req := genTestConfiguration(test.configuration, test.token)
+
+			jwt, err := validator.ValidateRequestWithLeeway(req, test.leeway)
 
 			if test.expectedErrorMsg != "" {
 				if err == nil {


### PR DESCRIPTION
This pull request adds the function `ValidateRequestWithLeeway` to support passing in a leeway to the token expiry time. `ValidateRequest` still behaves the same way since the default leeway of one minute is used (see `DefaultLeeway` from the `go-jose.v2/jwt` package). Please see the case "pass - token not expired because of leeway".