### PR TITLE
FromHeader and FromParams panic on nil request

### DIFF
--- a/token_extraction.go
+++ b/token_extraction.go
@@ -12,6 +12,8 @@ var (
 	// ErrTokenNotFound is returned by the ValidateRequest if the token was not
 	// found in the request.
 	ErrTokenNotFound = errors.New("Token not found")
+	// ErrNilRequest is returned by the FromHeader if the request is nil
+	ErrNilRequest = errors.New("Request nil")
 )
 
 // RequestTokenExtractor can extract a JWT
@@ -50,6 +52,9 @@ func FromMultiple(extractors ...RequestTokenExtractor) RequestTokenExtractor {
 // if not present.
 // TODO: Implement parsing form data.
 func FromHeader(r *http.Request) (*jwt.JSONWebToken, error) {
+	if r == nil {
+		return nil, ErrNilRequest
+	}
 	raw := ""
 	if h := r.Header.Get("Authorization"); len(h) > 7 && strings.EqualFold(h[0:7], "BEARER ") {
 		raw = h[7:]
@@ -62,6 +67,9 @@ func FromHeader(r *http.Request) (*jwt.JSONWebToken, error) {
 
 // FromParams returns the JWT when passed as the URL query param "token".
 func FromParams(r *http.Request) (*jwt.JSONWebToken, error) {
+	if r == nil {
+		return nil, ErrNilRequest
+	}
 	raw := r.URL.Query().Get("token")
 	if raw == "" {
 		return nil, ErrTokenNotFound


### PR DESCRIPTION
# Pull Request Report

### Description

I've added nil checks to both FromHeader and FromParams functions for the http.Request argument.
Discovered during internal testing that if the request object is nil it causes a panic. 

As a result of the check I created a new error value to be returned - ErrNilRequest that returns if the checks fail.

### Type of change

- [x] Bug fix (fix to an issue)
- [ ] New feature (changes to functionality)
- [ ] Big change (fix or feature that would cause existing functionality to work as expected)

### Testing

I've added tests to confirm this fix but you can remove the nil checks and run the tests to see trigger the panic.

**Test Configuration**

* Framework version:
* Language version: 1.11.4
* Browser version:

### Additional info

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings and errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
